### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/friendSystem/pom.xml
+++ b/friendSystem/pom.xml
@@ -24,7 +24,7 @@
     <jackson-core.version>2.4.3</jackson-core.version>
     <jedis.version>2.7.3</jedis.version>
 <!--     <quartz.version>1.5.2</quartz.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <amqp-client.version>3.6.0</amqp-client.version> -->
   </properties>

--- a/friendSystem/target/m2e-wtp/web-resources/META-INF/maven/com.mycompany.friendSystem/friendSystem/pom.xml
+++ b/friendSystem/target/m2e-wtp/web-resources/META-INF/maven/com.mycompany.friendSystem/friendSystem/pom.xml
@@ -24,7 +24,7 @@
     <jackson-core.version>2.4.3</jackson-core.version>
     <jedis.version>2.7.3</jedis.version>
 <!--     <quartz.version>1.5.2</quartz.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-logging.version>1.1.1</commons-logging.version>
     <amqp-client.version>3.6.0</amqp-client.version> -->
   </properties>

--- a/ssm/pom.xml
+++ b/ssm/pom.xml
@@ -25,7 +25,7 @@
     <jackson-core.version>2.4.3</jackson-core.version>
     <jedis.version>2.7.3</jedis.version>
     <quartz.version>1.5.2</quartz.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-logging.version>1.1.1</commons-logging.version>
   </properties>
 

--- a/ssm/target/m2e-wtp/web-resources/META-INF/maven/com.mycompany.ssm/ssm/pom.xml
+++ b/ssm/target/m2e-wtp/web-resources/META-INF/maven/com.mycompany.ssm/ssm/pom.xml
@@ -25,7 +25,7 @@
     <jackson-core.version>2.4.3</jackson-core.version>
     <jedis.version>2.7.3</jedis.version>
     <quartz.version>1.5.2</quartz.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-logging.version>1.1.1</commons-logging.version>
   </properties>
 


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/